### PR TITLE
Use `subset_by_index` keyword arg for `scipy.linalg.eigh`

### DIFF
--- a/parallel_transport_unfolding/ptu.py
+++ b/parallel_transport_unfolding/ptu.py
@@ -192,7 +192,7 @@ class PTU():
                 S, V = eigsh(G, self.embedding_dim, which="LA")
             else:
                 # dense eigensolver
-                S, V = eigh(G, eigvals=[N-self.embedding_dim, N-1])
+                S, V = eigh(G, subset_by_index=[N-self.embedding_dim, N-1])
             self.Embedding = V * np.sqrt(np.abs(S))
             self.logger.info('Performing MultiDimensional Scaling: done')
         except Exception:


### PR DESCRIPTION
`scipy.linalg.eigh` function has a `eigvals` keyword arg that has been removed in scipy 1.12. Per the [v1.11.1 doc](https://docs.scipy.org/doc/scipy-1.11.1/reference/generated/scipy.linalg.eigh.html), the `eigvals` keyword argument needs to be replaced by `subset_by_index`. 